### PR TITLE
Improve readability of welcome screen on small screens.

### DIFF
--- a/Construct/App/WelcomeView.swift
+++ b/Construct/App/WelcomeView.swift
@@ -14,11 +14,12 @@ struct WelcomeView: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("Welcome to Construct").font(Font.largeTitle.bold()).padding(.top, 22)
-
-            Spacer()
 
             ScrollView(.vertical) {
+                Text("Welcome to Construct").font(Font.largeTitle.bold()).padding(.top, 22)
+                
+                Spacer().padding()
+                
                 VStack(spacing: 18) {
                     ForEach(Self.items) { item in
                         HStack(spacing: 25) {
@@ -37,9 +38,10 @@ struct WelcomeView: View {
                         }
                     }
                 }
+                
+                Spacer()
             }
 
-            Spacer()
 
             Text("Check out the sample encounter or tap Continue to start building your own adventures.")
                 .font(.footnote)


### PR DESCRIPTION
The features are hard to read on smaller device sizes (e.g. iPhone SE), since the scroll area is very small.

To alleviate this, the title is incorporated in the scroll view and the spacer above the button explanation as well. This leaves a larger scrollable area which results in a more pleasant reading experience.