### PR TITLE
Update trait generation with structured output

### DIFF
--- a/Sources/OpenAIClient/JSONSchema.swift
+++ b/Sources/OpenAIClient/JSONSchema.swift
@@ -13,6 +13,7 @@ public struct JSONSchema: Codable, Equatable {
     public var properties: [String: JSONSchema]?
     public var required: [String]?
     public var `enum`: [String]?
+    public var items: JSONSchema?
 }
 
 public extension JSONSchema {
@@ -30,5 +31,9 @@ public extension JSONSchema {
 
     static func boolean(description: String? = nil) -> Self {
         JSONSchema(type: "boolean", description: description)
+    }
+
+    static func array(of items: JSONSchema, description: String? = nil) -> Self {
+        JSONSchema(type: "array", description: description, properties: nil, required: nil, enum: nil, items: items)
     }
 }

--- a/Sources/OpenAIClient/Models.swift
+++ b/Sources/OpenAIClient/Models.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public enum Model: String, Codable {
-    case gpt4 = "gpt-4"
+    /// Current standard GPT-4 model
+    case gpt4o = "gpt-4o"
+    /// Current standard GPT-3.5 model
     case gpt35Turbo = "gpt-3.5-turbo"
-    case Davinci3 = "text-davinci-003"
-    case Curie1 = "text-curie-001"
 }

--- a/Sources/OpenAIClient/OpenAIClient.swift
+++ b/Sources/OpenAIClient/OpenAIClient.swift
@@ -220,20 +220,23 @@ public struct ChatCompletionRequest: Encodable, Equatable {
     public var messages: [ChatMessage]
     public var functions: [Function]?
     public var functionCall: String?
+    public var responseFormat: ResponseFormat?
     public let maxTokens: Int?
     public let temperature: Float?
     var stream: Bool = false
 
     public init(
-        model: Model = .gpt35Turbo,
+        model: Model = .gpt4o,
         messages: [ChatMessage],
         functions: [Function]? = nil,
+        responseFormat: ResponseFormat? = nil,
         maxTokens: Int? = nil,
         temperature: Float? = nil
     ) {
         self.model = model
         self.messages = messages
         self.functions = functions
+        self.responseFormat = responseFormat
         self.maxTokens = maxTokens
         self.temperature = temperature
     }
@@ -277,6 +280,17 @@ public struct ChatCompletionRequest: Encodable, Equatable {
         struct Function: Encodable {
             var name: String
         }
+    }
+
+    public struct ResponseFormat: Encodable, Equatable {
+        public var type: String
+
+        public init(type: String) {
+            self.type = type
+        }
+
+        public static let jsonObject = Self(type: "json_object")
+        public static let text = Self(type: "text")
     }
 }
 

--- a/Tests/MechMuseTests/EncounterCombatantsTraitsTest.swift
+++ b/Tests/MechMuseTests/EncounterCombatantsTraitsTest.swift
@@ -1,6 +1,6 @@
 //
 //  EncounterCombatantsDescriptionTest.swift
-//  
+//
 //
 //  Created by Thomas Visser on 30/12/2022.
 //
@@ -15,15 +15,9 @@ final class EncounterCombatantsTraitsTest: XCTestCase {
 
     func testPrompt() {
         let request = GenerateCombatantTraitsRequest(combatantNames: ["Goblin 1", "Goblin 2", "Bugbear 1"])
-        XCTAssertNoDifference(request.prompt(), [
+        XCTAssertNoDifference(request.messages(), [
             .init(role: .system, content: "You are helping a Dungeons & Dragons DM create awesome encounters."),
-            .init(role: .user, content: """
-                The encounter has 3 monster(s): "Goblin 1", "Goblin 2", "Bugbear 1". Come up with gritty physical and personality traits that don't interfere with its stats and unique nickname that fits its traits. One trait of each type for each monster, limit each trait to a single sentence.
-
-                Format your answer as a correct YAML sequence of maps, with an entry for each monster. Each entry has fields name, physical, personality, nickname.
-                """
-            )
+            .init(role: .user, content: "Describe gritty physical and personality traits and a unique nickname for each of the following combatants: Goblin 1, Goblin 2, Bugbear 1. Respond in JSON with an object that has a `combatants` array of objects each containing `name`, `physical`, `personality`, and `nickname`.")
         ])
     }
-
 }

--- a/Tests/OpenAIClientTests/OpenAIClientTest.swift
+++ b/Tests/OpenAIClientTests/OpenAIClientTest.swift
@@ -27,18 +27,18 @@ final class OpenAIClientTest: XCTestCase {
     func testCompletion() async throws {
         // fake the response
         let responseData = """
-        {"id":"cmpl-6JmBNcxha3k89zV2L6XzBXZdt5gb0","object":"text_completion","created":1670171465,"model":"text-davinci-003","choices":[{"text":"\\n\\nThis is indeed a test.","index":0,"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}
+        {"id":"cmpl-6JmBNcxha3k89zV2L6XzBXZdt5gb0","object":"text_completion","created":1670171465,"model":"gpt-4o","choices":[{"text":"\\n\\nThis is indeed a test.","index":0,"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":8,"total_tokens":13}}
         """.data(using: .utf8)!
         httpClient.dataResponse = (responseData, HTTPURLResponse())
 
         let response = try await sut.perform(request: CompletionRequest(
-            model: .Davinci3,
+            model: .gpt4o,
             prompt: "Say this is a test"
         ))
 
         // Assert serialized request
         let requestData = """
-        {"model":"text-davinci-003","stream":false,"prompt":"Say this is a test"}
+        {"model":"gpt-4o","stream":false,"prompt":"Say this is a test"}
         """.data(using: .utf8)!
         try XCTAssertNoDifferenceJSONData(requestData, httpClient.dataRequests.last?.httpBody)
 
@@ -47,7 +47,7 @@ final class OpenAIClientTest: XCTestCase {
             id: "cmpl-6JmBNcxha3k89zV2L6XzBXZdt5gb0",
             object: "text_completion",
             created: 1670171465,
-            model: "text-davinci-003",
+            model: "gpt-4o",
             choices: [
                 .init(text: "\n\nThis is indeed a test.", finishReason: "stop")
             ]
@@ -58,18 +58,18 @@ final class OpenAIClientTest: XCTestCase {
         // fake the response
         httpClient.streamResponse = [
             """
-            {"id":"chatcmpl-6qJTvkR92tgHsu9nvdFSJSdhzk4yO","object":"chat.completion.chunk","created":1677925963,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}
+            {"id":"chatcmpl-6qJTvkR92tgHsu9nvdFSJSdhzk4yO","object":"chat.completion.chunk","created":1677925963,"model":"gpt-4o","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}
             """,
             """
-            {"id":"chatcmpl-6qJTvkR92tgHsu9nvdFSJSdhzk4yO","object":"chat.completion.chunk","created":1677925963,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":"As"},"index":0,"finish_reason":null}]}
+            {"id":"chatcmpl-6qJTvkR92tgHsu9nvdFSJSdhzk4yO","object":"chat.completion.chunk","created":1677925963,"model":"gpt-4o","choices":[{"delta":{"content":"As"},"index":0,"finish_reason":null}]}
             """,
             """
-            {"id":"chatcmpl-6qJTvkR92tgHsu9nvdFSJSdhzk4yO","object":"chat.completion.chunk","created":1677925963,"model":"gpt-3.5-turbo-0301","choices":[{"delta":{"content":" the"},"index":0,"finish_reason":null}]}
+            {"id":"chatcmpl-6qJTvkR92tgHsu9nvdFSJSdhzk4yO","object":"chat.completion.chunk","created":1677925963,"model":"gpt-4o","choices":[{"delta":{"content":" the"},"index":0,"finish_reason":null}]}
             """
         ].async.stream
 
         let response = try sut.stream(request: ChatCompletionRequest(
-            model: .gpt35Turbo,
+            model: .gpt4o,
             messages: [
                 .init(role: .system, content: "You are a D&D DM"),
                 .init(role: .user, content: "Narrate the attack of a goblin")
@@ -78,7 +78,7 @@ final class OpenAIClientTest: XCTestCase {
 
         // Assert serialized request
         let requestData = """
-        {"model":"gpt-3.5-turbo","stream":true,"messages":[{"content":"You are a D&D DM","role":"system"},{"content":"Narrate the attack of a goblin","role":"user"}]}
+        {"model":"gpt-4o","stream":true,"messages":[{"content":"You are a D&D DM","role":"system"},{"content":"Narrate the attack of a goblin","role":"user"}]}
         """.data(using: .utf8)!
         try XCTAssertNoDifferenceJSONData(requestData, httpClient.streamRequests.last?.httpBody)
 


### PR DESCRIPTION
## Summary
- add `gpt35Turbo` alongside `gpt4o`
- support `responseFormat` in `ChatCompletionRequest`
- request structured JSON for combatant traits
- parse traits from message content

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683f5d8bb5f0832cb28a6952cfe11156